### PR TITLE
make possible to use tools.jar on differnet platforms

### DIFF
--- a/giraffa-core/pom.xml
+++ b/giraffa-core/pom.xml
@@ -477,6 +477,15 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>tools.jar</groupId>
+                        <artifactId>tools.jar</artifactId>
+                        <version>1.7</version>
+                        <scope>system</scope>
+                        <systemPath>${tools-jar}</systemPath>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -167,4 +167,5 @@
             </properties>
         </profile>
     </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -143,4 +143,28 @@
         </pluginManagement>
     </build>
 
+    <profiles>
+        <profile>
+            <id>standard-jdk</id>
+            <activation>
+                <file>
+                    <exists>${java.home}/../lib/tools.jar</exists>
+                </file>
+            </activation>
+            <properties>
+                <tools-jar>${java.home}/../lib/tools.jar</tools-jar>
+            </properties>
+        </profile>
+        <profile>
+            <id>apple-jdk</id>
+            <activation>
+                <file>
+                    <exists>${java.home}/../Classes/classes.jar</exists>
+                </file>
+            </activation>
+            <properties>
+                <tools-jar>${java.home}/../Classes/classes.jar</tools-jar>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
As decribed here http://stackoverflow.com/questions/2022622/java-home-gets-mangled-by-maven tools.jar should be provided. 
For MacOSX this archive was renamed to Classes.jar.
To handle that we need to switch profiles and provide correct name for tools.jar
