### PR TITLE
Issue 134: GiraffaClient closes namespace before base DFSClient.

### DIFF
--- a/giraffa-core/src/main/java/org/apache/hadoop/hdfs/GiraffaClient.java
+++ b/giraffa-core/src/main/java/org/apache/hadoop/hdfs/GiraffaClient.java
@@ -69,7 +69,7 @@ public class GiraffaClient extends DFSClient {
 
   @Override // DFSClient
   public void close() throws IOException {
-    getNamespaceService().close();
     super.close();
+    getNamespaceService().close();
   }
 }


### PR DESCRIPTION
link #134 
