### PR TITLE
Issue 132: Auto migration of file leases.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,7 @@ Release 0.2.0 - unreleased
                statements. (Andrey Stepachev)
     Issue 104: Fix Java warnings excluding generated sources. (shv)
     Issue 127: Add FileSystemContractTestBase for Giraffa. (Andrey Stepachev)
+    Issue 132: Auto migration of file leases. (Plamen)
 
   DOCUMENTATION
 

--- a/giraffa-core/src/main/java/org/apache/giraffa/FileLease.java
+++ b/giraffa-core/src/main/java/org/apache/giraffa/FileLease.java
@@ -21,7 +21,6 @@ package org.apache.giraffa;
  * Leases provide exclusive access to files for write.
  */
 public class FileLease {
-  public static final long NO_LAST_UPDATE = -1L;
 
   public final String holder;
   public final String path;

--- a/giraffa-core/src/main/java/org/apache/giraffa/FileLease.java
+++ b/giraffa-core/src/main/java/org/apache/giraffa/FileLease.java
@@ -24,7 +24,7 @@ public class FileLease {
   public static final long NO_LAST_UPDATE = -1L;
 
   public final String holder;
-  public final transient String path;
+  public final String path;
   public final long lastUpdate;
 
   /**

--- a/giraffa-core/src/main/java/org/apache/giraffa/GiraffaPBHelper.java
+++ b/giraffa-core/src/main/java/org/apache/giraffa/GiraffaPBHelper.java
@@ -85,14 +85,16 @@ public class GiraffaPBHelper {
   public static FileLeaseProto convert(FileLease lease) {
     return FileLeaseProto.newBuilder()
         .setHolder(lease.getHolder())
+        .setPath(lease.getPath())
         .setLastUpdate(lease.getLastUpdate())
         .build();
   }
 
-  public static FileLease convert(FileLeaseProto leaseProto, String path) {
+  public static FileLease convert(FileLeaseProto leaseProto) {
     if(leaseProto == null)
       return null;
     String holder = leaseProto.getHolder();
+    String path = leaseProto.getPath();
     long lastUpdate = leaseProto.getLastUpdate();
     return new FileLease(holder, path, lastUpdate);
   }
@@ -125,10 +127,10 @@ public class GiraffaPBHelper {
    * @return
    * @throws IOException
    */
-  public static FileLease bytesToHdfsLease(byte[] bytes, String path)
+  public static FileLease bytesToHdfsLease(byte[] bytes)
       throws IOException {
     DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes));
-    return convert(FileLeaseProto.parseDelimitedFrom(in), path);
+    return convert(FileLeaseProto.parseDelimitedFrom(in));
   }
 
   /**

--- a/giraffa-core/src/main/java/org/apache/giraffa/GiraffaProtos.java
+++ b/giraffa-core/src/main/java/org/apache/giraffa/GiraffaProtos.java
@@ -1252,7 +1252,11 @@ public final class GiraffaProtos {
     boolean hasHolder();
     String getHolder();
     
-    // optional uint64 lastUpdate = 2;
+    // required string path = 2;
+    boolean hasPath();
+    String getPath();
+    
+    // required uint64 lastUpdate = 3;
     boolean hasLastUpdate();
     long getLastUpdate();
   }
@@ -1317,11 +1321,43 @@ public final class GiraffaProtos {
       }
     }
     
-    // optional uint64 lastUpdate = 2;
-    public static final int LASTUPDATE_FIELD_NUMBER = 2;
+    // required string path = 2;
+    public static final int PATH_FIELD_NUMBER = 2;
+    private java.lang.Object path_;
+    public boolean hasPath() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    public String getPath() {
+      java.lang.Object ref = path_;
+      if (ref instanceof String) {
+        return (String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        String s = bs.toStringUtf8();
+        if (com.google.protobuf.Internal.isValidUtf8(bs)) {
+          path_ = s;
+        }
+        return s;
+      }
+    }
+    private com.google.protobuf.ByteString getPathBytes() {
+      java.lang.Object ref = path_;
+      if (ref instanceof String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8((String) ref);
+        path_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+    
+    // required uint64 lastUpdate = 3;
+    public static final int LASTUPDATE_FIELD_NUMBER = 3;
     private long lastUpdate_;
     public boolean hasLastUpdate() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     public long getLastUpdate() {
       return lastUpdate_;
@@ -1329,6 +1365,7 @@ public final class GiraffaProtos {
     
     private void initFields() {
       holder_ = "";
+      path_ = "";
       lastUpdate_ = 0L;
     }
     private byte memoizedIsInitialized = -1;
@@ -1337,6 +1374,14 @@ public final class GiraffaProtos {
       if (isInitialized != -1) return isInitialized == 1;
       
       if (!hasHolder()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasPath()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasLastUpdate()) {
         memoizedIsInitialized = 0;
         return false;
       }
@@ -1351,7 +1396,10 @@ public final class GiraffaProtos {
         output.writeBytes(1, getHolderBytes());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeUInt64(2, lastUpdate_);
+        output.writeBytes(2, getPathBytes());
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeUInt64(3, lastUpdate_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -1368,7 +1416,11 @@ public final class GiraffaProtos {
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeUInt64Size(2, lastUpdate_);
+          .computeBytesSize(2, getPathBytes());
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(3, lastUpdate_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -1398,6 +1450,11 @@ public final class GiraffaProtos {
         result = result && getHolder()
             .equals(other.getHolder());
       }
+      result = result && (hasPath() == other.hasPath());
+      if (hasPath()) {
+        result = result && getPath()
+            .equals(other.getPath());
+      }
       result = result && (hasLastUpdate() == other.hasLastUpdate());
       if (hasLastUpdate()) {
         result = result && (getLastUpdate()
@@ -1415,6 +1472,10 @@ public final class GiraffaProtos {
       if (hasHolder()) {
         hash = (37 * hash) + HOLDER_FIELD_NUMBER;
         hash = (53 * hash) + getHolder().hashCode();
+      }
+      if (hasPath()) {
+        hash = (37 * hash) + PATH_FIELD_NUMBER;
+        hash = (53 * hash) + getPath().hashCode();
       }
       if (hasLastUpdate()) {
         hash = (37 * hash) + LASTUPDATE_FIELD_NUMBER;
@@ -1538,8 +1599,10 @@ public final class GiraffaProtos {
         super.clear();
         holder_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
-        lastUpdate_ = 0L;
+        path_ = "";
         bitField0_ = (bitField0_ & ~0x00000002);
+        lastUpdate_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
       
@@ -1585,6 +1648,10 @@ public final class GiraffaProtos {
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000002;
         }
+        result.path_ = path_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
         result.lastUpdate_ = lastUpdate_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -1605,6 +1672,9 @@ public final class GiraffaProtos {
         if (other.hasHolder()) {
           setHolder(other.getHolder());
         }
+        if (other.hasPath()) {
+          setPath(other.getPath());
+        }
         if (other.hasLastUpdate()) {
           setLastUpdate(other.getLastUpdate());
         }
@@ -1614,6 +1684,14 @@ public final class GiraffaProtos {
       
       public final boolean isInitialized() {
         if (!hasHolder()) {
+          
+          return false;
+        }
+        if (!hasPath()) {
+          
+          return false;
+        }
+        if (!hasLastUpdate()) {
           
           return false;
         }
@@ -1648,8 +1726,13 @@ public final class GiraffaProtos {
               holder_ = input.readBytes();
               break;
             }
-            case 16: {
+            case 18: {
               bitField0_ |= 0x00000002;
+              path_ = input.readBytes();
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000004;
               lastUpdate_ = input.readUInt64();
               break;
             }
@@ -1695,22 +1778,58 @@ public final class GiraffaProtos {
         onChanged();
       }
       
-      // optional uint64 lastUpdate = 2;
+      // required string path = 2;
+      private java.lang.Object path_ = "";
+      public boolean hasPath() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      public String getPath() {
+        java.lang.Object ref = path_;
+        if (!(ref instanceof String)) {
+          String s = ((com.google.protobuf.ByteString) ref).toStringUtf8();
+          path_ = s;
+          return s;
+        } else {
+          return (String) ref;
+        }
+      }
+      public Builder setPath(String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        path_ = value;
+        onChanged();
+        return this;
+      }
+      public Builder clearPath() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        path_ = getDefaultInstance().getPath();
+        onChanged();
+        return this;
+      }
+      void setPath(com.google.protobuf.ByteString value) {
+        bitField0_ |= 0x00000002;
+        path_ = value;
+        onChanged();
+      }
+      
+      // required uint64 lastUpdate = 3;
       private long lastUpdate_ ;
       public boolean hasLastUpdate() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000004) == 0x00000004);
       }
       public long getLastUpdate() {
         return lastUpdate_;
       }
       public Builder setLastUpdate(long value) {
-        bitField0_ |= 0x00000002;
+        bitField0_ |= 0x00000004;
         lastUpdate_ = value;
         onChanged();
         return this;
       }
       public Builder clearLastUpdate() {
-        bitField0_ = (bitField0_ & ~0x00000002);
+        bitField0_ = (bitField0_ & ~0x00000004);
         lastUpdate_ = 0L;
         onChanged();
         return this;
@@ -1757,9 +1876,9 @@ public final class GiraffaProtos {
       "\006offset\030\002 \002(\004\022\017\n\007corrupt\030\003 \002(\010\022-\n\nblockT" +
       "oken\030\004 \002(\0132\031.hadoop.common.TokenProto\"-\n" +
       "\020RenameStateProto\022\014\n\004flag\030\001 \002(\010\022\013\n\003src\030\002" +
-      " \001(\014\"4\n\016FileLeaseProto\022\016\n\006holder\030\001 \002(\t\022\022" +
-      "\n\nlastUpdate\030\002 \001(\004B&\n\022org.apache.giraffa" +
-      "B\rGiraffaProtos\240\001\001"
+      " \001(\014\"B\n\016FileLeaseProto\022\016\n\006holder\030\001 \002(\t\022\014" +
+      "\n\004path\030\002 \002(\t\022\022\n\nlastUpdate\030\003 \002(\004B&\n\022org." +
+      "apache.giraffaB\rGiraffaProtos\240\001\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -1787,7 +1906,7 @@ public final class GiraffaProtos {
           internal_static_giraffa_FileLeaseProto_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_giraffa_FileLeaseProto_descriptor,
-              new java.lang.String[] { "Holder", "LastUpdate", },
+              new java.lang.String[] { "Holder", "Path", "LastUpdate", },
               org.apache.giraffa.GiraffaProtos.FileLeaseProto.class,
               org.apache.giraffa.GiraffaProtos.FileLeaseProto.Builder.class);
           return null;

--- a/giraffa-core/src/main/java/org/apache/giraffa/LeaseManager.java
+++ b/giraffa-core/src/main/java/org/apache/giraffa/LeaseManager.java
@@ -47,18 +47,18 @@ public class LeaseManager {
    * Any of them can instantiate LeaseManager if it has not been created yet.
    * Once created its reference is stored in a shared environment.
    */
-  public synchronized static LeaseManager getLeaseManager(Object key) {
+  public synchronized static LeaseManager originateSharedLeaseManager(Object key) {
     LeaseManager leaseManager = leaseManagerMap.get(key);
-    if(leaseManager == null) {
-      leaseManager = new LeaseManager();
-      LOG.info("Creating new LeaseManager for " + key);
-      LeaseManager prevLeaseManager =
-          leaseManagerMap.putIfAbsent(key, leaseManager);
-      if(prevLeaseManager != null) {
-        leaseManager = prevLeaseManager;
-      }
-    } else {
+    if(leaseManager != null) {
       LOG.info("LeaseManager already exists in shared state for " + key);
+      return leaseManager;
+    }
+    leaseManager = new LeaseManager();
+    LOG.info("Creating new LeaseManager for " + key);
+    LeaseManager prevLeaseManager =
+        leaseManagerMap.putIfAbsent(key, leaseManager);
+    if(prevLeaseManager != null) {
+      leaseManager = prevLeaseManager;
     }
     return leaseManager;
   }
@@ -86,7 +86,6 @@ public class LeaseManager {
     return hlmAdapter.getLeases(clientName);
   }
 
-  @VisibleForTesting
   public Collection<FileLease> getLeases(String holder) {
     return hlmAdapter.getLeases(holder);
   }

--- a/giraffa-core/src/main/java/org/apache/giraffa/LeaseManager.java
+++ b/giraffa-core/src/main/java/org/apache/giraffa/LeaseManager.java
@@ -17,10 +17,10 @@
  */
 package org.apache.giraffa;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.giraffa.hbase.BlockManagementAgent;
@@ -34,12 +34,15 @@ import org.apache.hadoop.hdfs.server.namenode.HLMAdapter;
  * Implemented as HDFS.LeaseManager, which is accessed through HLMAdapter.
  */
 public class LeaseManager {
+  static final Log LOG = LogFactory.getLog(LeaseManager.class.getName());
 
-  private static final Log LOG =
-      LogFactory.getLog(LeaseManager.class.getName());
-
-  private static final ConcurrentMap<Object, LeaseManager> leaseManagerMap =
-      new ConcurrentHashMap<Object, LeaseManager>();
+  /**
+   * The map is needed in unit tests with MiniCluster.
+   * When multiple RegionServers run in the same JVM they should have
+   * different instances of LeaseManager.
+   */
+  private static final ConcurrentMap<String, LeaseManager> leaseManagerMap =
+      new ConcurrentHashMap<String, LeaseManager>();
 
   /**
    * Lease manager is a shared state between {@link NamespaceProcessor} and
@@ -47,7 +50,8 @@ public class LeaseManager {
    * Any of them can instantiate LeaseManager if it has not been created yet.
    * Once created its reference is stored in a shared environment.
    */
-  public synchronized static LeaseManager originateSharedLeaseManager(Object key) {
+  public synchronized static LeaseManager originateSharedLeaseManager(
+      String key) {
     LeaseManager leaseManager = leaseManagerMap.get(key);
     if(leaseManager != null) {
       LOG.info("LeaseManager already exists in shared state for " + key);

--- a/giraffa-core/src/main/java/org/apache/giraffa/hbase/BlockManagementAgent.java
+++ b/giraffa-core/src/main/java/org/apache/giraffa/hbase/BlockManagementAgent.java
@@ -26,7 +26,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.giraffa.FileField;
+import org.apache.giraffa.FileLease;
 import org.apache.giraffa.GiraffaPBHelper;
+import org.apache.giraffa.LeaseManager;
 import org.apache.giraffa.UnlocatedBlock;
 import org.apache.giraffa.hbase.NamespaceAgent.BlockAction;
 import org.apache.hadoop.conf.Configuration;
@@ -38,11 +40,16 @@ import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.KeyValueUtil;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.CoprocessorException;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
@@ -53,6 +60,9 @@ import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.io.EnumSetWritable;
+
+import static org.apache.giraffa.GiraffaConfiguration.GRFA_TABLE_NAME_DEFAULT;
+import static org.apache.giraffa.GiraffaConfiguration.GRFA_TABLE_NAME_KEY;
 
 /**
  * BlockManagementAgent provides access to underlying block management layer.
@@ -81,10 +91,15 @@ public class BlockManagementAgent extends BaseRegionObserver {
 
   private DistributedFileSystem hdfs;
   private AtomicLong temporaryFileId;
+  private LeaseManager leaseManager;
   private String clientName;
 
   @Override // BaseRegionObserver
-  public void start(CoprocessorEnvironment e) throws IOException {
+  public void start(CoprocessorEnvironment env) throws IOException {
+    if (!(env instanceof RegionCoprocessorEnvironment)) {
+      throw new CoprocessorException("Must be loaded on a table region!");
+    }
+    RegionCoprocessorEnvironment e = (RegionCoprocessorEnvironment) env;
     LOG.info("Start BlockManagementAgent...");
     Configuration conf = e.getConfiguration();
     String bmAddress = conf.get(CommonConfigurationKeys.FS_DEFAULT_NAME_KEY);
@@ -103,6 +118,9 @@ public class BlockManagementAgent extends BaseRegionObserver {
     }
     temporaryFileId = new AtomicLong(now());
     clientName = HDFSAdapter.getClientName(hdfs);
+
+    this.leaseManager =
+        LeaseManager.getLeaseManager(e.getRegionServerServices());
   }
 
   @Override // BaseRegionObserver
@@ -115,6 +133,44 @@ public class BlockManagementAgent extends BaseRegionObserver {
     }
     hdfs = null;
     */
+  }
+
+  @Override
+  public void postOpen(ObserverContext<RegionCoprocessorEnvironment> e) {
+    RegionCoprocessorEnvironment env = e.getEnvironment();
+    HRegion region = env.getRegion();
+    Configuration conf = env.getConfiguration();
+    if(!isNamespaceTable(region, conf)) {
+      return;
+    }
+    try {
+      RegionScanner scanner =
+          region.getScanner(new Scan(region.getStartKey(), region.getEndKey()));
+      List<KeyValue> kvs = new ArrayList<KeyValue>();
+      boolean hasNextRow;
+      do {
+        kvs.clear();
+        hasNextRow = scanner.nextRaw(kvs);
+        FileLease lease = getLease(kvs);
+        if(lease != null) {
+          LOG.info("Migrated FileLease: " + lease);
+          leaseManager.addLease(lease);
+          // LeaseManager will update lease with a new, higher, expiration date.
+          // Until a lease renewal or expiration happens, the lease of the row
+          // vs the lease in the LeaseManager will differ in expiration date.
+        }
+      } while(hasNextRow);
+    } catch (IOException exception) {
+      LOG.error("Failed to scan INodes cleanly post open of region: " + region,
+          exception);
+    }
+  }
+
+  private boolean isNamespaceTable(HRegion region, Configuration conf) {
+    TableName tableName = region.getRegionInfo().getTableName();
+    String namespaceTableName = conf.get(GRFA_TABLE_NAME_KEY,
+        GRFA_TABLE_NAME_DEFAULT);
+    return tableName.getNameAsString().equals(namespaceTableName);
   }
 
   @Override // BaseRegionObserver
@@ -161,10 +217,10 @@ public class BlockManagementAgent extends BaseRegionObserver {
     }
   }
 
-private void removeBlockAction(List<KeyValue> kvs) {
+  private void removeBlockAction(List<KeyValue> kvs) {
     KeyValue kv = findField(kvs, FileField.ACTION);
     kvs.remove(kv);
-}
+  }
 
   static KeyValue findField(List<KeyValue> kvs, FileField field) {
     for(KeyValue kv : kvs) {
@@ -185,6 +241,11 @@ private void removeBlockAction(List<KeyValue> kvs) {
     KeyValue kv = findField(kvs, FileField.BLOCK);
     return kv == null ? new ArrayList<UnlocatedBlock>() :
       byteArrayToBlockList(kv.getValue());
+  }
+
+  static FileLease getLease(List<KeyValue> kvs) {
+    KeyValue kv = findField(kvs, FileField.LEASE);
+    return kv == null ? null : byteArrayToLease(kv.getValue());
   }
 
   private void completeBlocks(List<KeyValue> kvs) throws IOException {
@@ -405,8 +466,23 @@ private void removeBlockAction(List<KeyValue> kvs) {
     }
     return null;
   }
-  
-  private static long now(){
+
+  /**
+   * Convert a byte array into a FileLease.
+   * @param lease
+   * @return FileLease representation of byte array of FileLease,
+   *  returns null if fails.
+   */
+  static FileLease byteArrayToLease(byte[] lease) {
+    try {
+      return GiraffaPBHelper.bytesToHdfsLease(lease);
+    } catch (IOException e) {
+      LOG.info("Error with serialization!", e);
+    }
+    return null;
+  }
+
+  private static long now() {
     return System.currentTimeMillis();
   }
 }

--- a/giraffa-core/src/main/java/org/apache/giraffa/hbase/BlockManagementAgent.java
+++ b/giraffa-core/src/main/java/org/apache/giraffa/hbase/BlockManagementAgent.java
@@ -120,8 +120,8 @@ public class BlockManagementAgent extends BaseRegionObserver {
     clientName = HDFSAdapter.getClientName(hdfs);
 
     this.leaseManager =
-        LeaseManager.originateSharedLeaseManager(
-            e.getRegionServerServices().getRpcServer().getListenerAddress());
+        LeaseManager.originateSharedLeaseManager(e.getRegionServerServices()
+            .getRpcServer().getListenerAddress().toString());
   }
 
   @Override // BaseRegionObserver
@@ -244,9 +244,9 @@ public class BlockManagementAgent extends BaseRegionObserver {
       byteArrayToBlockList(kv.getValue());
   }
 
-  static FileLease getFileLease(List<KeyValue> kvs) {
+  static FileLease getFileLease(List<KeyValue> kvs) throws IOException {
     KeyValue kv = findField(kvs, FileField.LEASE);
-    return kv == null ? null : byteArrayToLease(kv.getValue());
+    return kv == null ? null : GiraffaPBHelper.bytesToHdfsLease(kv.getValue());
   }
 
   private void completeBlocks(List<KeyValue> kvs) throws IOException {
@@ -462,21 +462,6 @@ public class BlockManagementAgent extends BaseRegionObserver {
   static List<DatanodeInfo[]> byteArrayToLocsList(byte[] locsArray) {
     try {
       return GiraffaPBHelper.bytesToBlockLocations(locsArray);
-    } catch (IOException e) {
-      LOG.info("Error with serialization!", e);
-    }
-    return null;
-  }
-
-  /**
-   * Convert a byte array into a FileLease.
-   * @param lease
-   * @return FileLease representation of byte array,
-   *  returns null if fails.
-   */
-  static FileLease byteArrayToLease(byte[] lease) {
-    try {
-      return GiraffaPBHelper.bytesToHdfsLease(lease);
     } catch (IOException e) {
       LOG.info("Error with serialization!", e);
     }

--- a/giraffa-core/src/main/java/org/apache/giraffa/hbase/FileFieldDeserializer.java
+++ b/giraffa-core/src/main/java/org/apache/giraffa/hbase/FileFieldDeserializer.java
@@ -124,13 +124,13 @@ public class FileFieldDeserializer {
         FileField.getLength()));
   }
 
-  public static FileLease getLease(Result res, String path) throws IOException {
+  public static FileLease getLease(Result res) throws IOException {
     if(getDirectory(res))
       return null;
     byte[] leaseByteArray = res.getValue(FileField.getFileAttributes(),
         FileField.getLease());
     if(leaseByteArray == null || leaseByteArray.length == 0)
       return null;
-    return GiraffaPBHelper.bytesToHdfsLease(leaseByteArray, path);
+    return GiraffaPBHelper.bytesToHdfsLease(leaseByteArray);
   }
 }

--- a/giraffa-core/src/main/java/org/apache/giraffa/hbase/INodeManager.java
+++ b/giraffa-core/src/main/java/org/apache/giraffa/hbase/INodeManager.java
@@ -346,7 +346,7 @@ public class INodeManager implements Closeable {
         FileFieldDeserializer.getRenameState(result),
         directory ? null : FileFieldDeserializer.getBlocks(result),
         directory ? null : FileFieldDeserializer.getLocations(result),
-        directory ? null : FileFieldDeserializer.getLease(result, src));
+        directory ? null : FileFieldDeserializer.getLease(result));
   }
 
   private ResultScanner getListingScanner(RowKey key)

--- a/giraffa-core/src/main/java/org/apache/giraffa/hbase/NamespaceProcessor.java
+++ b/giraffa-core/src/main/java/org/apache/giraffa/hbase/NamespaceProcessor.java
@@ -171,8 +171,8 @@ public class NamespaceProcessor implements ClientProtocol,
         checksumType);
 
     this.leaseManager =
-        LeaseManager.originateSharedLeaseManager(
-            e.getRegionServerServices().getRpcServer().getListenerAddress());
+        LeaseManager.originateSharedLeaseManager(e.getRegionServerServices()
+            .getRpcServer().getListenerAddress().toString());
   }
 
   @Override // Coprocessor

--- a/giraffa-core/src/main/java/org/apache/giraffa/hbase/NamespaceProcessor.java
+++ b/giraffa-core/src/main/java/org/apache/giraffa/hbase/NamespaceProcessor.java
@@ -171,7 +171,8 @@ public class NamespaceProcessor implements ClientProtocol,
         checksumType);
 
     this.leaseManager =
-        LeaseManager.getLeaseManager(e.getRegionServerServices());
+        LeaseManager.originateSharedLeaseManager(
+            e.getRegionServerServices().getRpcServer().getListenerAddress());
   }
 
   @Override // Coprocessor

--- a/giraffa-core/src/main/proto/grfa.proto
+++ b/giraffa-core/src/main/proto/grfa.proto
@@ -20,5 +20,6 @@ message RenameStateProto {
 
 message FileLeaseProto {
   required string holder = 1;
-  optional uint64 lastUpdate = 2;
+  required string path = 2;
+  required uint64 lastUpdate = 3;
 }

--- a/giraffa-core/src/test/java/org/apache/giraffa/TestLeaseManagement.java
+++ b/giraffa-core/src/test/java/org/apache/giraffa/TestLeaseManagement.java
@@ -133,6 +133,11 @@ public class TestLeaseManagement {
     assertThat(lease, is(nullValue()));
   }
 
+  /**
+   * This test shows that if a Region is to "migrate", either by split
+   * or by RegionServer shutdown, that an incomplete file with a lease migrates
+   * with the Region and that the lease is reloaded upon open and stays valid.
+   */
   @Test
   public void testLeaseMigration() throws IOException {
     String src = "/testLeaseFailure";
@@ -148,7 +153,9 @@ public class TestLeaseManagement {
       INode iNode = nodeManager.getINode(src);
       FileLease rowLease = iNode.getLease();
       LeaseManager leaseManager =
-          LeaseManager.getLeaseManager(regionServerThread.getRegionServer());
+          LeaseManager.originateSharedLeaseManager(
+              regionServerThread.getRegionServer().getRpcServer()
+                  .getListenerAddress());
       Collection<FileLease> leases =
           leaseManager.getLeases(rowLease.getHolder());
       assertThat(leases.size(), is(1));
@@ -188,7 +195,6 @@ public class TestLeaseManagement {
     assertThat(lease, is(notNullValue()));
     assertThat(lease.getHolder(), is(grfs.grfaClient.getClientName()));
     assertThat(lease.getPath(), is(src));
-    assertThat(lease.getLastUpdate(), is(not(FileLease.NO_LAST_UPDATE)));
     assertThat(lease.getLastUpdate() >= currentTime, is(true));
   }
 }

--- a/giraffa-core/src/test/java/org/apache/giraffa/TestLeaseManagement.java
+++ b/giraffa-core/src/test/java/org/apache/giraffa/TestLeaseManagement.java
@@ -17,6 +17,9 @@
  */
 package org.apache.giraffa;
 
+import java.util.Collection;
+import org.apache.hadoop.hbase.util.JVMClusterUtil;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
@@ -121,6 +124,53 @@ public class TestLeaseManagement {
 
       // keep stream open intentionally
       checkLease(src, currentTime);
+    } finally {
+      IOUtils.closeStream(outputStream);
+    }
+    INode iNode = nodeManager.getINode(src);
+    assertThat(iNode.getFileState(), is(GiraffaConstants.FileState.CLOSED));
+    FileLease lease = iNode.getLease();
+    assertThat(lease, is(nullValue()));
+  }
+
+  @Test
+  public void testLeaseMigration() throws IOException {
+    String src = "/testLeaseFailure";
+    Path path = new Path(src);
+    FSDataOutputStream outputStream = grfs.create(path);
+    try {
+      // keep stream open intentionally
+      cluster.stopRegionServer(0);
+      JVMClusterUtil.RegionServerThread regionServerThread =
+          cluster.startRegionServer();
+      regionServerThread.waitForServerOnline();
+
+      INode iNode = nodeManager.getINode(src);
+      FileLease rowLease = iNode.getLease();
+      LeaseManager leaseManager =
+          LeaseManager.getLeaseManager(regionServerThread.getRegionServer());
+      Collection<FileLease> leases =
+          leaseManager.getLeases(rowLease.getHolder());
+      assertThat(leases.size(), is(1));
+      FileLease leaseManagerLease = leases.iterator().next();
+      // The following asserts are here to highlight that as a result of
+      // migrating the FileLease across RegionServers we lose expiration date
+      // consistency between the row field and the LeaseManager.
+      assertThat(rowLease, is(not(equalTo(leaseManagerLease))));
+      assertThat(rowLease.getHolder(),
+          is(equalTo(leaseManagerLease.getHolder())));
+      assertThat(rowLease.getPath(), is(equalTo(leaseManagerLease.getPath())));
+      assertThat(rowLease.getLastUpdate(),
+          is(not(equalTo(leaseManagerLease.getLastUpdate()))));
+      // Renewing the lease restores the consistency.
+      grfs.grfaClient.getNamespaceService().renewLease(
+          grfs.grfaClient.getClientName());
+      iNode = nodeManager.getINode(src);
+      rowLease = iNode.getLease();
+      leases = leaseManager.getLeases(rowLease.getHolder());
+      assertThat(leases.size(), is(1));
+      leaseManagerLease = leases.iterator().next();
+      assertThat(rowLease, is(equalTo(leaseManagerLease)));
     } finally {
       IOUtils.closeStream(outputStream);
     }

--- a/giraffa-core/src/test/java/org/apache/giraffa/TestLeaseManagement.java
+++ b/giraffa-core/src/test/java/org/apache/giraffa/TestLeaseManagement.java
@@ -152,10 +152,9 @@ public class TestLeaseManagement {
 
       INode iNode = nodeManager.getINode(src);
       FileLease rowLease = iNode.getLease();
-      LeaseManager leaseManager =
-          LeaseManager.originateSharedLeaseManager(
-              regionServerThread.getRegionServer().getRpcServer()
-                  .getListenerAddress());
+      LeaseManager leaseManager = LeaseManager.originateSharedLeaseManager(
+          regionServerThread.getRegionServer().getRpcServer()
+          .getListenerAddress().toString());
       Collection<FileLease> leases =
           leaseManager.getLeases(rowLease.getHolder());
       assertThat(leases.size(), is(1));


### PR DESCRIPTION
#132

Couple things:
- Readded 'path' back into FileLease proto. This was necessary because otherwise we had no clean way to re-add the full lease back into the LeaseManager post RegionServer migration.
- Added a ConcurrentMap that maps a RegionServer reference to a LeaseManager. There should only ever be 1 LeaseManager per RegionServer and NSP and BMA should share the references.
- Added a test to showcase the migration.
- Be careful to note that when the migration occurs, it has the effect of renewing the lease. During this time, the lease in the row and the lease in the LeaseManager will be divergent, the LeaseManager lease will have a higher expiration date (expires later). This is remedied when a renewLease() occurs.
