### PR TITLE
Issue 136: NamespaceProcessor throws NPE in renewLease().

### DIFF
--- a/giraffa-core/src/main/java/org/apache/giraffa/hbase/NamespaceProcessor.java
+++ b/giraffa-core/src/main/java/org/apache/giraffa/hbase/NamespaceProcessor.java
@@ -871,6 +871,8 @@ public class NamespaceProcessor implements ClientProtocol,
   public void renewLease(String clientName) throws AccessControlException,
       IOException {
     Collection<FileLease> leases = leaseManager.renewLease(clientName);
+    if(leases == null || leases.isEmpty())
+      return;
     // TODO: Bulk put / mutate INodes.
     for(FileLease lease : leases) {
       INode iNode = nodeManager.getINode(lease.getPath());


### PR DESCRIPTION
#136
