### PR TITLE
Issue 212: Fix Jenkins build post-121.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ ext {
   jmockit_version = '1.17'
   hamcrest_version = '1.3'
   pmd_version = '5.3.1'
+
+  protobuf_compiler = properties['protobuf.compiler'];
 }
 
 subprojects {

--- a/giraffa-core/build.gradle
+++ b/giraffa-core/build.gradle
@@ -76,6 +76,10 @@ project(':giraffa-core') {
     // so that the build will fail if this specific
     // version of the compiler is not present.
     version = protobuf_version
+    if(protobuf_compiler != null) {
+      println "Using custom protobuf compiler: $protobuf_compiler"
+      compiler = protobuf_compiler
+    }
   }
 
   description = """Core module"""


### PR DESCRIPTION
#212

In order to fix the Jenkins build we need to be able to specify a custom protobuf compiler to use for our protobuf plugin.
