### PR TITLE
Issue-223: Capital letter problem when formatting Giraffa

### DIFF
--- a/giraffa-core/src/main/java/org/apache/giraffa/GiraffaFileSystem.java
+++ b/giraffa-core/src/main/java/org/apache/giraffa/GiraffaFileSystem.java
@@ -101,7 +101,8 @@ public class GiraffaFileSystem extends FileSystem {
                             boolean isConfirmationNeeded) throws IOException {
     if (isConfirmationNeeded) {
       System.err.print("Re-format Giraffa file system ? (Y or N) ");
-      if (!(System.in.read() == 'Y')) {
+      int flag = System.in.read();
+      if (!(flag == 'Y') && !(flag == 'y')) {
         System.err.println("Format aborted.");
         return;
       }


### PR DESCRIPTION
Link to #223
Fixed the problem of only recognizing capital "Y" when asking "Re-format Giraffa file system ?"
Test has been done and it shows the issue is fixed.
