### PR TITLE
Issue 230: Directory rename deletes children whose row keys are unchanged

### DIFF
--- a/giraffa-core/src/main/java/org/apache/giraffa/hbase/NamespaceProcessor.java
+++ b/giraffa-core/src/main/java/org/apache/giraffa/hbase/NamespaceProcessor.java
@@ -556,11 +556,13 @@ public class NamespaceProcessor implements ClientProtocol,
         final List<INodeDirectory> dirsToDelete = new ArrayList<>();
         nodeManager.map(it.previous(), new Function() {
           @Override
-          public void apply(INode input) throws IOException {
-            if (!input.isDir())
-              deleteFile(INodeFile.valueOf(input), deleteBlocks);
-            else
-              dirsToDelete.add(INodeDirectory.valueOf(input));
+          public void apply(INode child) throws IOException {
+            if (!child.getRenameState().getFlag()) {
+              if (!child.isDir())
+                deleteFile(INodeFile.valueOf(child), deleteBlocks);
+              else
+                dirsToDelete.add(INodeDirectory.valueOf(child));
+            }
           }
         });
 


### PR DESCRIPTION
Link to #230 